### PR TITLE
리팩토링 - navbar 겹침문제, NonUserMain 경로 변경, warning 제거

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,7 @@
     transform: rotate(360deg);
   }
 }
+
+body {
+  padding-top: 66px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,15 @@
-import React from 'react';
-import { Routes, Route } from 'react-router-dom';
-import logo from "./assets/image/logo.png";
+import React from "react";
+import { Routes, Route } from "react-router-dom";
 import "./App.css";
-import MainPage from './pages/MainPage/MainPage';
+import MainPage from "./pages/MainPage/MainPage";
 
 function App() {
   return (
-  <>
-    <Routes>
-      <Route element={<MainPage />} path="/" exact />
-    </Routes>
-  </>
+    <>
+      <Routes>
+        <Route element={<MainPage />} path="/" exact />
+      </Routes>
+    </>
   );
 }
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -87,4 +87,4 @@ const Header = () => {
   );
 };
 
-export { Header };
+export default Header;

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import reportWebVitals from "./reportWebVitals";
 import "bootstrap/dist/css/bootstrap.min.css";
-import { Header } from "./components/Header/Header";
-import { BrowserRouter } from 'react-router-dom';
+import Header from "./components/Header/Header";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));

--- a/src/pages/Login/Login.css
+++ b/src/pages/Login/Login.css
@@ -1,0 +1,21 @@
+.login {
+  height: 100vh;
+  width: 45vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.login-title {
+  text-align: center;
+}
+
+.form-control {
+  width: 100%;
+}
+
+.form-button {
+  width: 100%;
+  margin: 0 auto;
+}

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -22,6 +22,7 @@ const Login = () => {
       e.stopPropagation();
       setValidated(true);
     } else {
+      // TODO: 로그인 API
     }
   };
   return (
@@ -64,4 +65,4 @@ const Login = () => {
   );
 };
 
-export { Login };
+export default Login;

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { Button, Form } from "react-bootstrap";
+import "./Login.css";
+
+const Login = () => {
+  const [id, setId] = useState("");
+  const [password, setPassword] = useState("");
+  const [validated, setValidated] = useState(false);
+
+  const onChangeId = (e) => {
+    setId(e.target.value);
+    setValidated(false);
+  };
+  const onChangePassword = (e) => {
+    setPassword(e.target.value);
+    setValidated(false);
+  };
+  const handleSubmit = (e) => {
+    const form = e.currentTarget;
+    if (form.checkValidity() === false) {
+      e.preventDefault();
+      e.stopPropagation();
+      setValidated(true);
+    } else {
+    }
+  };
+  return (
+    <div className="login">
+      <h2 className="login-title">로그인</h2>
+      <Form
+        className="login-form"
+        action=""
+        noValidate
+        validated={validated}
+        onSubmit={handleSubmit}
+      >
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            type="text"
+            className="form-control"
+            id="form-id"
+            placeholder="ID"
+            onChange={onChangeId}
+            value={id}
+          />
+        </Form.Group>
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            type="password"
+            className="form-control"
+            id="form-password"
+            placeholder="Password"
+            onChange={onChangePassword}
+            value={password}
+          />
+        </Form.Group>
+        <Button type="submit" className="form-button btn btn-primary">
+          로그인
+        </Button>
+      </Form>
+    </div>
+  );
+};
+
+export { Login };

--- a/src/pages/NonUserMain/NonUserMain.css
+++ b/src/pages/NonUserMain/NonUserMain.css
@@ -1,7 +1,6 @@
 /* 비로그인 상단 */
 .main-top {
-  padding-top: 66px;
-  min-height: 100vh;
+  min-height: calc(100vh - 66px);
   background-color: #8fbaff;
   color: #fff;
   display: flex;

--- a/src/pages/NonUserMain/NonUserMain.js
+++ b/src/pages/NonUserMain/NonUserMain.js
@@ -100,4 +100,4 @@ const NonUserMain = () => {
   );
 };
 
-export { NonUserMain };
+export default NonUserMain;

--- a/src/pages/Register/Register.css
+++ b/src/pages/Register/Register.css
@@ -1,0 +1,21 @@
+.register {
+  height: 100vh;
+  width: 45vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.register-title {
+  text-align: center;
+}
+
+.form-control {
+  width: 100%;
+}
+
+.form-button {
+  width: 100%;
+  margin: 0 auto;
+}

--- a/src/pages/Register/Register.css
+++ b/src/pages/Register/Register.css
@@ -1,5 +1,5 @@
 .register {
-  height: 100vh;
+  height: calc(100vh - 66px);
   width: 45vh;
   display: flex;
   flex-direction: column;

--- a/src/pages/Register/Register.js
+++ b/src/pages/Register/Register.js
@@ -35,6 +35,7 @@ const Register = () => {
       e.stopPropagation();
       setValidated(true);
     } else {
+      // TODO: Register API, 중복 체크 API 등등
     }
   };
   return (
@@ -120,4 +121,4 @@ const Register = () => {
   );
 };
 
-export { Register };
+export default Register;

--- a/src/pages/Register/Register.js
+++ b/src/pages/Register/Register.js
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { Button, Form } from "react-bootstrap";
+import "./Register.css";
+
+const Register = () => {
+  const [id, setId] = useState("");
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [samePassword, setSamePassword] = useState(true);
+  const [validated, setValidated] = useState(false);
+
+  const onChangeId = (e) => {
+    setId(e.target.value);
+  };
+  const onChangeUsername = (e) => {
+    setUsername(e.target.value);
+  };
+  const onChangeEmail = (e) => {
+    setEmail(e.target.value);
+  };
+  const onChangePassword = (e) => {
+    setPassword(e.target.value);
+    setSamePassword(e.target.value === confirmPassword);
+  };
+  const onChangeConfirmPassword = (e) => {
+    setConfirmPassword(e.target.value);
+    setSamePassword(e.target.value === password);
+  };
+  const handleSubmit = (e) => {
+    const form = e.currentTarget;
+    if (form.checkValidity() === false) {
+      e.preventDefault();
+      e.stopPropagation();
+      setValidated(true);
+    } else {
+    }
+  };
+  return (
+    <div className="register">
+      <h2 className="register-title">회원가입</h2>
+      <Form
+        className="register-form"
+        action=""
+        noValidate
+        validated={validated}
+        onSubmit={handleSubmit}
+      >
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            type="text"
+            className="form-control"
+            id="form-id"
+            placeholder="ID"
+            onChange={onChangeId}
+            value={id}
+          />
+        </Form.Group>
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            type="text"
+            className="form-control"
+            id="form-username"
+            placeholder="Username"
+            onChange={onChangeUsername}
+            value={username}
+          />
+        </Form.Group>
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            type="email"
+            className="form-control"
+            id="form-email"
+            placeholder="Email"
+            onChange={onChangeEmail}
+            value={email}
+          />
+        </Form.Group>
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            isInvalid={!samePassword}
+            pattern={confirmPassword}
+            type="password"
+            className="form-control"
+            id="form-password"
+            placeholder="Password"
+            onChange={onChangePassword}
+            value={password}
+          />
+          <Form.Control.Feedback type="invalid">
+            비밀번호를 확인해주세요.
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group className="form-group my-3">
+          <Form.Control
+            required
+            isInvalid={!samePassword}
+            pattern={password}
+            type="password"
+            className="form-control"
+            id="form-confirm-password"
+            placeholder="Confirm Password"
+            onChange={onChangeConfirmPassword}
+            value={confirmPassword}
+          />
+          <Form.Control.Feedback type="invalid">
+            비밀번호를 확인해주세요.
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Button type="submit" className="form-button btn btn-primary">
+          회원가입
+        </Button>
+      </Form>
+    </div>
+  );
+};
+
+export { Register };


### PR DESCRIPTION
1. navbar가 fixed되었을 때 생기는 겹침 문제를 `body { padding-top:66px; }` 스타일 적용을 통해 해결하였습니다.
    - 고정적으로 body에 대해 66px padding이 생기기 때문에 페이지의 height 관련 대처가 필요할 수 있습니다. (`height: calc(100vh - 66px)`)
    - 아래 변경 전 및 변경 후 스크린샷을 업로드 하였습니다.
2. NonUserMain의 경로가 `component/`에서 `pages/`로 변경되었습니다.
    - 비로그인 메인의 경우 컴포넌트가 아닌 페이지 단위가 맞다고 판단하여 변경하였습니다.
3. Warning 제거
    -  netlify의 자동 페이지 빌드 시 warning을 error로 간주해 빌드가 실패하는 현상을 해결하였습니다. build 옵션에 `CI=false`를 추가하였습니다.
<img width="1624" alt="Before" src="https://user-images.githubusercontent.com/25370441/167293721-e8e88598-4d74-42f4-ba2d-a16b1602af4b.png">
(변경 전, navbar 영역과 body 영역이 겹침)
<img width="1580" alt="After" src="https://user-images.githubusercontent.com/25370441/167293722-334e73a6-95ae-4ae2-ac7c-a68019256ae1.png">
(변경 후, navbar 영역과 body 영역이 겹치지 않음. 하지만 padding으로 인해 100vh 스타일을 주었을 시 66px 만큼 높이가 넘어감을 알 수 있습니다.)