### PR TITLE
모달 구현 - 미리보기, 파일 공유

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ccbox-fe",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -15,6 +16,7 @@
         "react-bootstrap": "^2.3.1",
         "react-dom": "^18.0.0",
         "react-icons": "^4.3.1",
+        "react-player": "^2.10.1",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -4260,8 +4262,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4276,9 +4276,7 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -10804,6 +10802,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10968,6 +10971,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -13315,6 +13323,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-icons": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
@@ -13332,6 +13345,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-player": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.10.1.tgz",
+      "integrity": "sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==",
+      "dependencies": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -19151,13 +19179,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {},
+      "requires": {
+        "ajv": "^8.0.0"
+      },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "optional": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -19168,9 +19197,7 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "optional": true,
-          "peer": true
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -23883,6 +23910,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -24013,6 +24045,11 @@
       "requires": {
         "fs-monkey": "1.0.3"
       }
+    },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -25566,6 +25603,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-icons": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
@@ -25581,6 +25623,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-player": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.10.1.tgz",
+      "integrity": "sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==",
+      "requires": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",
@@ -26601,6 +26655,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
+        "postcss": "^8.4.12",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-bootstrap": "^2.3.1",
     "react-dom": "^18.0.0",
     "react-icons": "^4.3.1",
+    "react-player": "^2.10.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/src/components/MainPageComponent.js
+++ b/src/components/MainPageComponent.js
@@ -1,8 +1,8 @@
 import { Fragment, useEffect, useState, React } from "react";
-import { BsFillCircleFill } from 'react-icons/bs';
-import { ImArrowUp } from 'react-icons/im';
-import { BiTrashAlt } from 'react-icons/bi';
-import { Button, Table } from 'react-bootstrap';
+import { BsFillCircleFill } from "react-icons/bs";
+import { ImArrowUp } from "react-icons/im";
+import { BiTrashAlt } from "react-icons/bi";
+import { Button, Table } from "react-bootstrap";
 import "../styles/MainPage.css";
 import DocLogo from "../assets/image/doc_logo.png";
 import ExcelLogo from "../assets/image/excel_logo.png";
@@ -11,102 +11,155 @@ import PptLogo from "../assets/image/presentation_logo.png";
 import VideoLogo from "../assets/image/video_logo.png";
 import Sidebar from "../common/Sidebar/Sidebar";
 
-const MainPageComponent = ({ openUpload, openCreateDir }) => {
-    return (
-        <div className="main-layout">
-            <Sidebar />
-            <div className="main-block">
-                <div className="path-block">
-                    <span className="directory-list">
-                        <span className="directory-path">Root / </span>
-                        <span className="directory-path">22-1 CCBOX / </span>
-                        <span className="directory-path dir-current">프로토타입</span>
-                    </span>
-                    <div className="highlight-block">
-                        <span className="circle-margin high-red"><BsFillCircleFill size="18"/></span>
-                        <span className="circle-margin high-blue"><BsFillCircleFill size="18"/></span>
-                        <span className="circle-margin high-green"><BsFillCircleFill size="18"/></span>
-                        <span className="high-yellow"><BsFillCircleFill size="18"/></span>
-                    </div>
-                </div>
-                <div className="buttons-block">
-                    <Button variant="primary" className="button-align" onClick={openUpload}>업로드 <ImArrowUp className="icon-margin"/></Button>
-                    <Button variant="light" onClick={openCreateDir}>폴더생성</Button>
-                    <span className="border-line">|</span>
-                    <Button variant="light">파일공유</Button>
-                    <Button variant="light" className="button-align">삭제 <BiTrashAlt className="icon-margin"/></Button>
-                </div>
-                <div className="filelist-block">
-                    <Table responsive="md">
-                        <thead>
-                            <tr>
-                                <th>파일명</th>
-                                <th>업로드 / 마지막 수정</th>
-                                <th>액세스 가능 유저</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            <tr>
-                                <td className="file-name">
-                                    <input type="checkbox" name="xxx" value="yyy" className="file-check mg-right"/>
-                                    <span className="file-logo mg-right">
-                                        <img src={ImgLogo} alt="img-logo" className="logo-image"/>
-                                    </span>
-                                    logo.png
-                                </td>
-                                <td>2022-03-28 12:10</td>
-                                <td>본인만</td>
-                            </tr>
-                            <tr>
-                                <td className="file-name">
-                                    <input type="checkbox" name="xxx" value="yyy" className="file-check mg-right"/>
-                                    <span className="file-logo mg-right">
-                                        <img src={VideoLogo} alt="img-logo" className="logo-image"/>
-                                    </span>
-                                    lecture1.mp4
-                                </td>
-                                <td>2022-03-28 12:10</td>
-                                <td>유명현, 김지수</td>
-                            </tr>
-                            <tr>
-                                <td className="file-name">
-                                    <input type="checkbox" name="xxx" value="yyy" className="file-check mg-right"/>
-                                    <span className="file-logo mg-right">
-                                        <img src={PptLogo} alt="img-logo" className="logo-image"/>
-                                    </span>
-                                    mid-term.ppt
-                                </td>
-                                <td>2022-03-28 12:10</td>
-                                <td>유명현 외 5명</td>
-                            </tr>
-                            <tr>
-                                <td className="file-name">
-                                    <input type="checkbox" name="xxx" value="yyy" className="file-check mg-right"/>
-                                    <span className="file-logo mg-right">
-                                        <img src={DocLogo} alt="img-logo" className="logo-image"/>
-                                    </span>
-                                    spec.docx
-                                </td>
-                                <td>2022-03-28 12:10</td>
-                                <td>유명현 외 5명</td>
-                            </tr>
-                            <tr>
-                                <td className="file-name">
-                                    <input type="checkbox" name="xxx" value="yyy" className="file-check mg-right"/>
-                                    <span className="file-logo mg-right">
-                                        <img src={ExcelLogo} alt="img-logo" className="logo-image"/>
-                                    </span>
-                                    액셀연습.xlsx
-                                </td>
-                                <td>2022-03-28 12:10</td>
-                                <td>유명현 외 5명</td>
-                            </tr>
-                        </tbody>
-                    </Table>
-                </div>
-            </div>
+const MainPageComponent = ({ openUpload, openCreateDir, openShareFile }) => {
+  return (
+    <div className="main-layout">
+      <Sidebar />
+      <div className="main-block">
+        <div className="path-block">
+          <span className="directory-list">
+            <span className="directory-path">Root / </span>
+            <span className="directory-path">22-1 CCBOX / </span>
+            <span className="directory-path dir-current">프로토타입</span>
+          </span>
+          <div className="highlight-block">
+            <span className="circle-margin high-red">
+              <BsFillCircleFill size="18" />
+            </span>
+            <span className="circle-margin high-blue">
+              <BsFillCircleFill size="18" />
+            </span>
+            <span className="circle-margin high-green">
+              <BsFillCircleFill size="18" />
+            </span>
+            <span className="high-yellow">
+              <BsFillCircleFill size="18" />
+            </span>
+          </div>
         </div>
-    );
+        <div className="buttons-block">
+          <Button
+            variant="primary"
+            className="button-align"
+            onClick={openUpload}
+          >
+            업로드 <ImArrowUp className="icon-margin" />
+          </Button>
+          <Button variant="light" onClick={openCreateDir}>
+            폴더생성
+          </Button>
+          <span className="border-line">|</span>
+          <Button variant="light" onClick={openShareFile}>
+            파일공유
+          </Button>
+          <Button variant="light" className="button-align">
+            삭제 <BiTrashAlt className="icon-margin" />
+          </Button>
+        </div>
+        <div className="filelist-block">
+          <Table responsive="md">
+            <thead>
+              <tr>
+                <th>파일명</th>
+                <th>업로드 / 마지막 수정</th>
+                <th>액세스 가능 유저</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="file-name">
+                  <input
+                    type="checkbox"
+                    name="xxx"
+                    value="yyy"
+                    className="file-check mg-right"
+                  />
+                  <span className="file-logo mg-right">
+                    <img src={ImgLogo} alt="img-logo" className="logo-image" />
+                  </span>
+                  logo.png
+                </td>
+                <td>2022-03-28 12:10</td>
+                <td>본인만</td>
+              </tr>
+              <tr>
+                <td className="file-name">
+                  <input
+                    type="checkbox"
+                    name="xxx"
+                    value="yyy"
+                    className="file-check mg-right"
+                  />
+                  <span className="file-logo mg-right">
+                    <img
+                      src={VideoLogo}
+                      alt="img-logo"
+                      className="logo-image"
+                    />
+                  </span>
+                  lecture1.mp4
+                </td>
+                <td>2022-03-28 12:10</td>
+                <td>유명현, 김지수</td>
+              </tr>
+              <tr>
+                <td className="file-name">
+                  <input
+                    type="checkbox"
+                    name="xxx"
+                    value="yyy"
+                    className="file-check mg-right"
+                  />
+                  <span className="file-logo mg-right">
+                    <img src={PptLogo} alt="img-logo" className="logo-image" />
+                  </span>
+                  mid-term.ppt
+                </td>
+                <td>2022-03-28 12:10</td>
+                <td>유명현 외 5명</td>
+              </tr>
+              <tr>
+                <td className="file-name">
+                  <input
+                    type="checkbox"
+                    name="xxx"
+                    value="yyy"
+                    className="file-check mg-right"
+                  />
+                  <span className="file-logo mg-right">
+                    <img src={DocLogo} alt="img-logo" className="logo-image" />
+                  </span>
+                  spec.docx
+                </td>
+                <td>2022-03-28 12:10</td>
+                <td>유명현 외 5명</td>
+              </tr>
+              <tr>
+                <td className="file-name">
+                  <input
+                    type="checkbox"
+                    name="xxx"
+                    value="yyy"
+                    className="file-check mg-right"
+                  />
+                  <span className="file-logo mg-right">
+                    <img
+                      src={ExcelLogo}
+                      alt="img-logo"
+                      className="logo-image"
+                    />
+                  </span>
+                  액셀연습.xlsx
+                </td>
+                <td>2022-03-28 12:10</td>
+                <td>유명현 외 5명</td>
+              </tr>
+            </tbody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default MainPageComponent;

--- a/src/components/MainPageComponent.js
+++ b/src/components/MainPageComponent.js
@@ -11,7 +11,12 @@ import PptLogo from "../assets/image/presentation_logo.png";
 import VideoLogo from "../assets/image/video_logo.png";
 import Sidebar from "../common/Sidebar/Sidebar";
 
-const MainPageComponent = ({ openUpload, openCreateDir, openShareFile }) => {
+const MainPageComponent = ({
+  openUpload,
+  openCreateDir,
+  openShareFile,
+  openPreview,
+}) => {
   return (
     <div className="main-layout">
       <Sidebar />
@@ -90,7 +95,7 @@ const MainPageComponent = ({ openUpload, openCreateDir, openShareFile }) => {
                     value="yyy"
                     className="file-check mg-right"
                   />
-                  <span className="file-logo mg-right">
+                  <span className="file-logo mg-right" onClick={openPreview}>
                     <img
                       src={VideoLogo}
                       alt="img-logo"

--- a/src/components/PreviewComponent.js
+++ b/src/components/PreviewComponent.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { IoMdClose } from "react-icons/io";
+import "../styles/Preview.css";
+import "../styles/ModalStyle.css";
+import ReactPlayer from "react-player";
+
+const PreviewComponent = (props) => {
+  // 열기, 닫기를 부모로부터 받아옴
+  const { open, close } = props;
+
+  return (
+    // 모달이 열릴때 openModal 클래스가 생성된다.
+    <div className={open ? "open-modal modal" : "modal"}>
+      {open ? (
+        <div className="create-block">
+          <div className="block-top">
+            <div className="block-title">미리보기</div>
+            <div className="close-modal" onClick={close}>
+              <IoMdClose />
+            </div>
+          </div>
+          <hr />
+          <div className="create-section">
+            {/* TODO: url 관리 방식 - props? recoil?*/}
+            <ReactPlayer
+              className="player"
+              url="https://d2bg6z9x0yg9ip.cloudfront.net/file_example_MP4_640_3MG.mp4"
+              width="100%"
+              height="100%"
+              controls={true}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default PreviewComponent;

--- a/src/components/ShareFileComponent.js
+++ b/src/components/ShareFileComponent.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { IoMdClose } from "react-icons/io";
+import "../styles/ShareFile.css";
+import "../styles/ModalStyle.css";
+import { Button } from "react-bootstrap";
+
+const ShareFileComponent = (props) => {
+  // 열기, 닫기를 부모로부터 받아옴
+  const { open, close } = props;
+
+  return (
+    // 모달이 열릴때 openModal 클래스가 생성된다.
+    <div className={open ? "open-modal modal" : "modal"}>
+      {open ? (
+        <div className="create-block">
+          <div className="block-top">
+            <div className="block-title">파일 공유</div>
+            <div className="close-modal" onClick={close}>
+              <IoMdClose />
+            </div>
+          </div>
+          <hr />
+          <div className="create-section">
+            <form>
+              <input placeholder="유저명" className="input-box"></input>
+              <div className="share-user-list">공유 유저 리스트</div>
+              <div className="create-button">
+                <Button variant="primary">파일공유</Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ShareFileComponent;

--- a/src/containers/MainPageContainer.js
+++ b/src/containers/MainPageContainer.js
@@ -3,11 +3,13 @@ import MainPageComponent from "../components/MainPageComponent";
 import FileUploadComponent from "../components/FileUploadComponent";
 import CreateDirComponent from "../components/CreateDirComponent";
 import ShareFileComponent from "../components/ShareFileComponent";
+import PreviewComponent from "../components/PreviewComponent";
 
 const MainPageContainer = () => {
   const [uploadOpen, setUploadOpen] = useState(false);
   const [createDirOpen, setCreateDirOpen] = useState(false);
   const [shareFileOpen, setShareFileOpen] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const openUpload = () => {
     setUploadOpen(true);
@@ -30,16 +32,25 @@ const MainPageContainer = () => {
     setShareFileOpen(false);
   };
 
+  const openPreview = () => {
+    setPreviewOpen(true);
+  };
+  const closePreview = () => {
+    setPreviewOpen(false);
+  };
+
   return (
     <>
       <MainPageComponent
         openUpload={openUpload}
         openCreateDir={openCreateDir}
         openShareFile={openShareFile}
+        openPreview={openPreview}
       />
       <FileUploadComponent open={uploadOpen} close={closeUpload} />
       <CreateDirComponent open={createDirOpen} close={closeCreateDir} />
       <ShareFileComponent open={shareFileOpen} close={closeShareFile} />
+      <PreviewComponent open={previewOpen} close={closePreview} />
     </>
   );
 };

--- a/src/containers/MainPageContainer.js
+++ b/src/containers/MainPageContainer.js
@@ -1,33 +1,47 @@
-import {React, useState} from 'react';
-import MainPageComponent from '../components/MainPageComponent';
-import FileUploadComponent from '../components/FileUploadComponent';
-import CreateDirComponent from '../components/CreateDirComponent';
+import { React, useState } from "react";
+import MainPageComponent from "../components/MainPageComponent";
+import FileUploadComponent from "../components/FileUploadComponent";
+import CreateDirComponent from "../components/CreateDirComponent";
+import ShareFileComponent from "../components/ShareFileComponent";
 
 const MainPageContainer = () => {
-    const [uploadOpen, setUploadOpen] = useState(false);
-    const [createDirOpne, setCreateDirOpen] = useState(false);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [createDirOpne, setCreateDirOpen] = useState(false);
+  const [shareFileOpen, setShareFileOpen] = useState(false);
 
-    const openUpload = () => {
-        setUploadOpen(true);
-    };
-    const closeUpload = () => {
-        setUploadOpen(false);
-    };
+  const openUpload = () => {
+    setUploadOpen(true);
+  };
+  const closeUpload = () => {
+    setUploadOpen(false);
+  };
 
-    const openCreateDir = () => {
-        setCreateDirOpen(true);
-    };
-    const closeCreateDir = () => {
-        setCreateDirOpen(false);
-    };
+  const openCreateDir = () => {
+    setCreateDirOpen(true);
+  };
+  const closeCreateDir = () => {
+    setCreateDirOpen(false);
+  };
 
-    return (
-        <>
-            <MainPageComponent openUpload={openUpload} openCreateDir={openCreateDir} />
-            <FileUploadComponent open={uploadOpen} close={closeUpload}/>
-            <CreateDirComponent open={createDirOpne} close={closeCreateDir}/>
-        </>
-    );
+  const openShareFile = () => {
+    setShareFileOpen(true);
+  };
+  const closeShareFile = () => {
+    setShareFileOpen(false);
+  };
+
+  return (
+    <>
+      <MainPageComponent
+        openUpload={openUpload}
+        openCreateDir={openCreateDir}
+        openShareFile={openShareFile}
+      />
+      <FileUploadComponent open={uploadOpen} close={closeUpload} />
+      <CreateDirComponent open={createDirOpne} close={closeCreateDir} />
+      <ShareFileComponent open={shareFileOpen} close={closeShareFile} />
+    </>
+  );
 };
 
 export default MainPageContainer;

--- a/src/containers/MainPageContainer.js
+++ b/src/containers/MainPageContainer.js
@@ -6,7 +6,7 @@ import ShareFileComponent from "../components/ShareFileComponent";
 
 const MainPageContainer = () => {
   const [uploadOpen, setUploadOpen] = useState(false);
-  const [createDirOpne, setCreateDirOpen] = useState(false);
+  const [createDirOpen, setCreateDirOpen] = useState(false);
   const [shareFileOpen, setShareFileOpen] = useState(false);
 
   const openUpload = () => {
@@ -38,7 +38,7 @@ const MainPageContainer = () => {
         openShareFile={openShareFile}
       />
       <FileUploadComponent open={uploadOpen} close={closeUpload} />
-      <CreateDirComponent open={createDirOpne} close={closeCreateDir} />
+      <CreateDirComponent open={createDirOpen} close={closeCreateDir} />
       <ShareFileComponent open={shareFileOpen} close={closeShareFile} />
     </>
   );

--- a/src/containers/PreviewContainer.js
+++ b/src/containers/PreviewContainer.js
@@ -1,0 +1,14 @@
+import { React, useState } from "react";
+import PreviewComponent from "../components/PreviewComponent";
+
+const PreviewContainer = () => {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
+  return <PreviewComponent open={modalOpen} close={closeModal} />;
+};
+
+export default PreviewContainer;

--- a/src/containers/ShareFileContainer.js
+++ b/src/containers/ShareFileContainer.js
@@ -1,0 +1,14 @@
+import { React, useState } from "react";
+import ShareFileComponent from "../components/ShareFileComponent";
+
+const ShareFileContainer = () => {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
+  return <ShareFileComponent open={modalOpen} close={closeModal} />;
+};
+
+export default ShareFileContainer;

--- a/src/styles/Preview.css
+++ b/src/styles/Preview.css
@@ -1,0 +1,28 @@
+.create-block {
+  width: 80%;
+  height: 75%;
+  background-color: #ffffff;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.create-section {
+  width: 100%;
+  height: 80%;
+}
+
+/* .input-box {
+  display: block;
+  width: 100%;
+  height: 2.2rem;
+  margin-top: 5rem;
+} */
+
+/* .share-user-list {
+  margin-top: 0.5rem;
+} */
+
+/* .create-button {
+  float: right;
+  margin-top: 1rem;
+} */

--- a/src/styles/ShareFile.css
+++ b/src/styles/ShareFile.css
@@ -1,0 +1,28 @@
+.create-block {
+  width: 50%;
+  height: 45%;
+  background-color: #ffffff;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.create-section {
+  width: 100%;
+  height: 60%;
+}
+
+.input-box {
+  display: block;
+  width: 100%;
+  height: 2.2rem;
+  margin-top: 5rem;
+}
+
+.share-user-list {
+  margin-top: 0.5rem;
+}
+
+.create-button {
+  float: right;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
미리보기, 파일 공유 모달을 구현하였습니다.
[deploy preview](https://deploy-preview-8--ccbox.netlify.app/)에서 lecture.mp4 제목 왼쪽 로고를 클릭하면 미리보기 모달을 확인할 수 있습니다.
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/25370441/168802380-78a9a0d6-ff84-4495-859c-dd3ce6ff6897.png">

현재 파일 목록의 코드 다음과 같습니다.
```js
<tr>
    <td className="file-name">
        <input
        type="checkbox"
        name="xxx"
        value="yyy"
        className="file-check mg-right"
        />
        <span className="file-logo mg-right" onClick={openPreview}>
        <img
            src={VideoLogo}
            alt="img-logo"
            className="logo-image"
        />
        </span>
        lecture1.mp4
    </td>
    <td>2022-03-28 12:10</td>
    <td>유명현, 김지수</td>
</tr>
```
UX측면을 고려했을 때 파일명을 클릭하였을 때 미리보기 모달이 나오도록 하는 것이 좋다고 판단하였습니다. 하지만 파일명이 td의 text로 되어있어 td에 `onClick={openPreview}`를 설정하게 되면 checkbox를 클릭하였을 때 미리보기 모달이 나오는 현상이 발생합니다.
파일명을 div, span, p등의 태그로 한번 감싼 후, 이 태그에 `onClick={openPreview}`를 설정하는 방식으로 해결할 수 있을 것 같습니다.